### PR TITLE
fix a local test issue of ports reuse

### DIFF
--- a/benchmark/benchmark/config.py
+++ b/benchmark/benchmark/config.py
@@ -68,7 +68,6 @@ class Committee:
         num_authorities = len(addresses)
 
         for i, (name, hosts) in enumerate(addresses.items()):
-            port = base_port
             host = hosts.pop(0)
             consensus_addr = {
                 'consensus_to_consensus': f'{host}:{port}',

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -3,10 +3,10 @@ from fabric import task
 
 from benchmark.local import LocalBench
 from benchmark.logs import ParseError, LogParser
-from benchmark.utils import Print
+from benchmark.utils import Print, BenchError
 from benchmark.plot import Ploter, PlotError
 from benchmark.instance import InstanceManager
-from benchmark.remote import Bench, BenchError
+from benchmark.remote import Bench
 
 
 @task


### PR DESCRIPTION
Currently, there are two issues when running the codes on a local machine.

1. Ports are reused by distinct nodes: nodes fail to bind the used ports (`./benchmark/benchmark/config.py/#L71`), leading to the failure of initializing nodes.
2. The configuration files of the google cloud account are hardcoded in the `./benchmark/benchmark/instance.py`: if you don't have these configuration files, you would not able to run even the local test.

This pull request fixed the first issue by deleting the code that reused ports. 